### PR TITLE
Add support for English-translated games

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,6 +162,7 @@ target_sources(system3 PRIVATE
   sys/nact_sys1.cpp
   sys/nact_sys2.cpp
   sys/nact_sys3.cpp
+  sys/localization.cpp
   )
 
 target_compile_definitions(system3 PRIVATE

--- a/src/sys/ags.cpp
+++ b/src/sys/ags.cpp
@@ -220,6 +220,7 @@ AGS::AGS(NACT* parent, const char* fontfile) : nact(parent), dirty(false)
 			SET_MENU(i, 452, 14, 627, 214, true);
 			break;
 		case CRC32_VAMPIRE:
+		case CRC32_VAMPIRE_ENG:
 			SET_TEXT(i, 8, 255, 615, 383, false);
 			SET_MENU(i, 448, 11, 615, 224, false);
 			break;

--- a/src/sys/ags_draw.cpp
+++ b/src/sys/ags_draw.cpp
@@ -43,6 +43,7 @@ void AGS::load_cg(int page, int transparent)
 				load_vsp(data, page, transparent);	// 暫定
 				break;
 			case CRC32_VAMPIRE:
+			case CRC32_VAMPIRE_ENG:
 				load_vsp2l(data, page, transparent);
 				break;
 			default:

--- a/src/sys/ags_pms.cpp
+++ b/src/sys/ags_pms.cpp
@@ -41,7 +41,11 @@ void AGS::load_pms(uint8* data, int page, int transparent)
 				tmp_palette[i * 16 + j] = SETPALETTE256(r, g, b);
 			}
 		}
-		if(nact->crc32_a == CRC32_RANCE41 || nact->crc32_a == CRC32_RANCE42 || nact->crc32_a == CRC32_HASHIRIONNA2) {
+		if(nact->crc32_a == CRC32_RANCE41 ||
+		   nact->crc32_a == CRC32_RANCE41_ENG ||
+		   nact->crc32_a == CRC32_RANCE42 ||
+		   nact->crc32_a == CRC32_RANCE42_ENG ||
+		   nact->crc32_a == CRC32_HASHIRIONNA2) {
 			// 上下16色は取得しない
 			for(int i = 1; i < 15; i++) {
 				for(int j = 0; j < 16; j++) {
@@ -73,7 +77,11 @@ void AGS::load_pms(uint8* data, int page, int transparent)
 	// パレット展開
 	if (nact->sys_ver == 3) {
 		if((extract_palette && extract_palette_cg[page]) || nact->crc32_a == CRC32_FUNNYBEE_CD) {
-			if(nact->crc32_a == CRC32_RANCE41 || nact->crc32_a == CRC32_RANCE42 || nact->crc32_a == CRC32_HASHIRIONNA2) {
+			if(nact->crc32_a == CRC32_RANCE41 ||
+			   nact->crc32_a == CRC32_RANCE41_ENG ||
+			   nact->crc32_a == CRC32_RANCE42 ||
+			   nact->crc32_a == CRC32_RANCE42_ENG ||
+			   nact->crc32_a == CRC32_HASHIRIONNA2) {
 				// 上下16色は展開しない
 				for(int i = 1; i < 15; i++) {
 					for(int j = 0; j < 16; j++) {

--- a/src/sys/crc32.h
+++ b/src/sys/crc32.h
@@ -30,6 +30,7 @@
 #define CRC32_TENGU		0xc942ff58	// あぶないてんぐ伝説
 #define CRC32_TOUSHIN_HINT	0xac337537	// 闘神都市 ヒントディスク
 #define CRC32_VAMPIRE		0x957bcfbf	// Little Vampire
+#define CRC32_VAMPIRE_ENG		0x61985a7f	// Little Vampire (English) Patch 1.5
 #define CRC32_YAKATA		0x8cef6fa6	// ALICEの館
 
 // SYSTEM2
@@ -60,7 +61,9 @@
 #define CRC32_PROSTUDENTG_CD	0xfb0e4a63	// Prostudent -G- (CD)
 #define CRC32_PROG_OMAKE	0x8ba18bff	// Prostudent G おまけ (CRC32 of AGAME.DAT)
 #define CRC32_RANCE41		0xa43fb4b6	// Rance 4.1
+#define CRC32_RANCE41_ENG	0x811f4ff3	// Rance 4.1 (English) 1.5 Beta
 #define CRC32_RANCE42		0x04d24d1e	// Rance 4.2
+#define CRC32_RANCE42_ENG	0xa97cc370	// Rance 4.2 (English) 1.5 Beta
 #define CRC32_AYUMI_CD		0xd2bed9ee	// あゆみちゃん物語 (CD)
 #define CRC32_AYUMI_JISSHA_256	0x00d15a2b	// あゆみちゃん物語 実写版
 #define CRC32_AYUMI_JISSHA_FULL	0x5f66ff1d	// あゆみちゃん物語 フルカラー実写版

--- a/src/sys/dri.cpp
+++ b/src/sys/dri.cpp
@@ -113,6 +113,7 @@ uint8* DRI::load_mda(uint32 crc32_a, uint32 crc32_b, int page, int* size)
 			name = "AMUS_T1";
 			break;
 		case CRC32_VAMPIRE:		// Little Vampire
+		case CRC32_VAMPIRE_ENG:
 			name = "AMUS_LP2";
 			break;
 		case CRC32_YAKATA:		// ALICEの館
@@ -163,9 +164,11 @@ uint8* DRI::load_mda(uint32 crc32_a, uint32 crc32_b, int page, int* size)
 			name = "AMUS_PSG.MDA";
 			break;
 		case CRC32_RANCE41:		// Rance 4.1
+		case CRC32_RANCE41_ENG:
 			name = "AMUS_R41.MDA";
 			break;
 		case CRC32_RANCE42:		// Rance 4.2
+		case CRC32_RANCE42_ENG:
 			name = "AMUS_R42.MDA";
 			break;
 		case CRC32_AYUMI_CD:		// あゆみちゃん物語 (CD)

--- a/src/sys/localization.cpp
+++ b/src/sys/localization.cpp
@@ -1,0 +1,34 @@
+#include "localization.h"
+
+namespace strings {
+
+const char* back[] = {
+	"\x96\xDF\x82\xE9", // "戻る" in SJIS
+	"Back",
+};
+const char* next_page[] = {
+	"\x8E\x9F\x82\xCC\x83\x79\x81\x5B\x83\x57", // "次のページ" in SJIS
+	"Next Page",
+};
+const char* dps_initial_tvars[][7] = {
+	{
+		"\x83\x4A\x83\x58\x83\x5E\x83\x80", // "カスタム" in SJIS
+		"\x83\x8A\x81\x5B\x83\x69\x83\x58", // "リーナス" in SJIS
+		"\x82\xA9\x82\xC2\x82\xDD", // "かつみ" in SJIS
+		"\x97\x52\x94\xFC\x8E\x71", // "由美子" in SJIS
+		"\x82\xA2\x82\xC2\x82\xDD", // "いつみ" in SJIS
+		"\x82\xD0\x82\xC6\x82\xDD", // "ひとみ" in SJIS
+		"\x90\x5E\x97\x9D\x8E\x71", // "真理子" in SJIS
+	},
+	{
+		"Custom",
+		"Linus",
+		"Katsumi",
+		"Yumiko",
+		"Itsumi",
+		"Hitomi",
+		"Mariko",
+	},
+};
+
+} // namespace strings

--- a/src/sys/localization.h
+++ b/src/sys/localization.h
@@ -1,0 +1,17 @@
+#ifndef _LOCALIZATION_H_
+#define _LOCALIZATION_H_
+
+enum Language {
+	JAPANESE = 0,
+	ENGLISH = 1,
+};
+
+namespace strings {
+
+extern const char* back[];
+extern const char* next_page[];
+extern const char* dps_initial_tvars[][7];
+
+} // namespace strings
+
+#endif // _LOCALIZATION_H_

--- a/src/sys/nact.cpp
+++ b/src/sys/nact.cpp
@@ -151,6 +151,12 @@ void NACT::execute()
 		opening();
 	}
 
+	// Skip SysEng's "new style" marker
+	if (scenario_page == 0 && scenario_addr == 2 &&
+		memcmp(&scenario_data[2], "REV", 3) == 0) {
+		scenario_addr = 5;
+	}
+
 	// １コマンド実行
 	prev_addr = scenario_addr;
 	uint8 cmd = getd();

--- a/src/sys/nact.cpp
+++ b/src/sys/nact.cpp
@@ -18,7 +18,7 @@ extern SDL_Window* g_window;
 // 初期化
 
 NACT::NACT(int sys_ver, uint32 crc32_a, uint32 crc32_b, const char* font_file, const MAKOConfig& mako_config)
-	: sys_ver(sys_ver), crc32_a(crc32_a), crc32_b(crc32_b)
+	: sys_ver(sys_ver), crc32_a(crc32_a), crc32_b(crc32_b), lang(get_language())
 {
 	platform_initialize();
 

--- a/src/sys/nact.cpp
+++ b/src/sys/nact.cpp
@@ -275,10 +275,13 @@ void NACT::execute()
 		case 'Z':
 			cmd_z();
 			break;
+		case '\'': case '"':
+			message(cmd);
+			break;
 		default:
 			if(is_1byte_message(cmd) || is_2byte_message(cmd)) {
 				ungetd();
-				message();
+				message(0);
 			} else {
 				if(cmd >= 0x20 && cmd < 0x7f) {
 					fatal("Unknown Command: '%c' at page = %d, addr = %d", cmd, scenario_page, prev_addr);
@@ -290,24 +293,36 @@ void NACT::execute()
 	}
 }
 
-void NACT::message()
+void NACT::message(uint8_t terminator)
 {
-	uint8* begin = &scenario_data[scenario_addr];
-	uint8* end = begin;
-	for (;;) {
-		if (is_1byte_message(*end))
-			end++;
-		else if (is_2byte_message(*end))
-			end += 2;
-		else
-			break;
-	}
-	int len = end - begin;
-	scenario_addr += len;
+	char buf[200];
+	if (terminator) {  // SysEng
+		uint8* p = &scenario_data[scenario_addr];
+		char* q = buf;
+		while (*p != terminator) {
+			if (*p == '\\')
+				p++;
+			*q++ = *p++;
+		}
+		*q = '\0';
+		scenario_addr += p + 1 - &scenario_data[scenario_addr];
+	} else {
+		uint8* begin = &scenario_data[scenario_addr];
+		uint8* end = begin;
+		for (;;) {
+			if (is_1byte_message(*end))
+				end++;
+			else if (is_2byte_message(*end))
+				end += 2;
+			else
+				break;
+		}
+		int len = end - begin;
+		scenario_addr += len;
 
-	char* buf = (char*)alloca(len + 1);
-	strncpy(buf, reinterpret_cast<char*>(begin), len);
-	buf[len] = '\0';
+		strncpy(buf, reinterpret_cast<char*>(begin), len);
+		buf[len] = '\0';
+	}
 
 	ags->draw_text(buf, text_wait_enb);
 

--- a/src/sys/nact.h
+++ b/src/sys/nact.h
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include "../common.h"
+#include "localization.h"
 
 #define RND var[ 0]
 #define D01 var[ 1]
@@ -76,9 +77,6 @@
 #define MAX_OBJ 256
 #define MAX_CAPTION 32
 #define MAX_PCM 256
-
-constexpr char SJIS_BACK[] = "\x96\xDF\x82\xE9"; // "戻る" in SJIS
-constexpr char SJIS_NEXT_PAGE [] = "\x8E\x9F\x82\xCC\x83\x79\x81\x5B\x83\x57"; // "次のページ" in SJIS
 
 class AGS;
 class MAKO;
@@ -253,6 +251,7 @@ public:
 	const char* get_game_id();
 	static const int get_sys_ver(uint32 crc32_a, uint32 crc32_b);
 	const char* get_title();
+	Language get_language();
 	void text_wait();
 	void set_skip_menu_state(bool enabled, bool checked);
 
@@ -260,6 +259,7 @@ public:
 	int sys_ver;
 	uint32 crc32_a;		// ADISK
 	uint32 crc32_b;		// BDISK for D.P.S -SG- and Super D.P.S
+	Language lang;
 
 	// for Y27
 	char tvar[10][33];

--- a/src/sys/nact.h
+++ b/src/sys/nact.h
@@ -127,7 +127,7 @@ protected:
 	char tvar_stack[30][10][22];
 //	int tvar_index;
 
-	void message();
+	void message(uint8 terminator);
 
 	// Commands
 	virtual void cmd_calc() = 0;

--- a/src/sys/nact_crc32.cpp
+++ b/src/sys/nact_crc32.cpp
@@ -148,3 +148,13 @@ const char* NACT::get_title()
 		return entry->title;
 	return NULL;
 }
+
+Language NACT::get_language()
+{
+	// TODO: Add Language as a field of the CRCTable struct
+	if (crc32_a == CRC32_VAMPIRE_ENG ||
+		crc32_a == CRC32_RANCE41_ENG ||
+		crc32_a == CRC32_RANCE42_ENG)
+		return ENGLISH;
+	return JAPANESE;
+}

--- a/src/sys/nact_crc32.cpp
+++ b/src/sys/nact_crc32.cpp
@@ -35,6 +35,7 @@ const struct CRCTable {
 	{"tengu", 1, "あぶないてんぐ伝説", CRC32_TENGU},
 	{"toushin_hint", 1, "闘神都市 ヒントディスク", CRC32_TOUSHIN_HINT},
 	{"little_vampire", 1, "Little Vampire", CRC32_VAMPIRE},
+	{"little_vampire_eng", 1, "Little Vampire", CRC32_VAMPIRE_ENG},
 	{"yakata", 1, "ALICEの館", CRC32_YAKATA},
 
 	{"ayumi_fd", 2, "あゆみちゃん物語", CRC32_AYUMI_FD},
@@ -60,7 +61,9 @@ const struct CRCTable {
 	{"prog_cd", 3, "Prostudent G", CRC32_PROSTUDENTG_CD},
 	{"prog_omake", 3, "Prostudent G おまけ", CRC32_PROG_OMAKE},
 	{"rance41", 3, "ランス 4.1 〜お薬工場を救え！〜", CRC32_RANCE41},
+	{"rance41_eng", 3, "Rance 4.1 ~Save the Medicine Plant!~", CRC32_RANCE41_ENG},
 	{"rance42", 3, "ランス 4.2 〜エンジェル組〜", CRC32_RANCE42},
+	{"rance42_eng", 3, "Rance 4.2 ~Angel Army~", CRC32_RANCE42_ENG},
 	{"ayumi_cd", 3, "あゆみちゃん物語", CRC32_AYUMI_CD},
 	{"ayumi_live_256", 3, "あゆみちゃん物語 実写版", CRC32_AYUMI_JISSHA_256},
 	{"ayumi_live_full", 3, "あゆみちゃん物語 フルカラー実写版", CRC32_AYUMI_JISSHA_FULL},

--- a/src/sys/nact_sys1.cpp
+++ b/src/sys/nact_sys1.cpp
@@ -74,13 +74,8 @@ NACT_Sys1::NACT_Sys1(uint32 crc32_a, uint32 crc32_b, const char* font_file, cons
 	//case CRC32_DPS_SG2:
 	case CRC32_DPS_SG3:
 		text_refresh = false;
-		strcpy_s(tvar[0], 22, "\x83\x4A\x83\x58\x83\x5E\x83\x80"); // "カスタム" in SJIS
-		strcpy_s(tvar[1], 22, "\x83\x8A\x81\x5B\x83\x69\x83\x58"); // "リーナス" in SJIS
-		strcpy_s(tvar[2], 22, "\x82\xA9\x82\xC2\x82\xDD"); // "かつみ" in SJIS
-		strcpy_s(tvar[3], 22, "\x97\x52\x94\xFC\x8E\x71"); // "由美子" in SJIS
-		strcpy_s(tvar[4], 22, "\x82\xA2\x82\xC2\x82\xDD"); // "いつみ" in SJIS
-		strcpy_s(tvar[5], 22, "\x82\xD0\x82\xC6\x82\xDD"); // "ひとみ" in SJIS
-		strcpy_s(tvar[6], 22, "\x90\x5E\x97\x9D\x8E\x71"); // "真理子" in SJIS
+		for (int i = 0; i < 7; i++)
+			strcpy(tvar[i], strings::dps_initial_tvars[lang][i]);
 		break;
 	case CRC32_INTRUDER:
 		paint_x = paint_y = map_page = 0;
@@ -431,7 +426,7 @@ top2:
 		// 次のページを追加
 		ags->menu_dest_x = 2;
 		ags->menu_dest_y += 2;
-		ags->draw_text(SJIS_NEXT_PAGE);
+		ags->draw_text(strings::next_page[lang]);
 		id[index++] = -1;
 		ags->menu_dest_y += ags->menu_font_size + 2;
 	}
@@ -502,7 +497,7 @@ top:
 		// 戻るを追加
 		ags->menu_dest_x = 2;
 		ags->menu_dest_y += 2;
-		ags->draw_text(SJIS_BACK);
+		ags->draw_text(strings::back[lang]);
 		id[index++] = 0;
 		ags->menu_dest_y += ags->menu_font_size + 2;
 	} else {
@@ -528,14 +523,14 @@ top2:
 		// 戻るを追加
 		ags->menu_dest_x = 2;
 		ags->menu_dest_y += 2;
-		ags->draw_text(SJIS_BACK);
+		ags->draw_text(strings::back[lang]);
 		id[index++] = 0;
 		ags->menu_dest_y += ags->menu_font_size + 2;
 
 		// 次のページを追加
 		ags->menu_dest_x = 2;
 		ags->menu_dest_y += 2;
-		ags->draw_text(SJIS_NEXT_PAGE);
+		ags->draw_text(strings::next_page[lang]);
 		id[index++] = -1;
 		ags->menu_dest_y += ags->menu_font_size + 2;
 	}

--- a/src/sys/nact_sys1.cpp
+++ b/src/sys/nact_sys1.cpp
@@ -1102,6 +1102,9 @@ void NACT_Sys1::cmd_y()
 					ags->draw_box(param);
 				}
 				break;
+			case 240:
+				ags->draw_hankaku = (param == 1) ? true : false;
+				break;
 			case 253:
 				post_quit = false;
 				fatal_error = true;

--- a/src/sys/nact_sys1.cpp
+++ b/src/sys/nact_sys1.cpp
@@ -212,6 +212,11 @@ void NACT_Sys1::cmd_branch()
 			} else if(is_2byte_message(cmd)) {
 				// message (2 bytes)
 				getd();
+			} else if (cmd == '\'' || cmd == '"') {  // SysEng
+				for (uint8_t c = getd(); c != cmd; c = getd()) {
+					if (c == '\\')
+						getd();
+				}
 			} else {
 				if(cmd >= 0x20 && cmd < 0x7f) {
 					fatal("Unknown Command: '%c' at page = %d, addr = %d", cmd, scenario_page, prev_addr);

--- a/src/sys/nact_sys1.cpp
+++ b/src/sys/nact_sys1.cpp
@@ -103,6 +103,7 @@ void NACT_Sys1::opening()
 		ags->load_cg(74, -1);
 		break;
 	case CRC32_VAMPIRE:
+	case CRC32_VAMPIRE_ENG:
 		mako->play_music(4);
 		ags->load_cg(3, -1);
 		WAIT(2000);

--- a/src/sys/nact_sys2.cpp
+++ b/src/sys/nact_sys2.cpp
@@ -503,7 +503,7 @@ void NACT_Sys2::cmd_open_obj(int verb)
 	// 戻るを追加
 	ags->menu_dest_x = 2;
 	ags->menu_dest_y += 2;
-	ags->draw_text(SJIS_BACK);
+	ags->draw_text(strings::back[lang]);
 	id[index++] = 0;
 	ags->menu_dest_y += ags->menu_font_size + 2;
 	ags->draw_menu = false;

--- a/src/sys/nact_sys2.cpp
+++ b/src/sys/nact_sys2.cpp
@@ -171,15 +171,17 @@ void NACT_Sys2::cmd_branch()
 			} else if(cmd == 'L') {
 				getd();
 			} else if(cmd == 'M') {
-				for(;;) {
-					uint8 val = getd();
-					if(is_1byte_message(val)) {
-						// message (1 byte)
-					} else if(is_2byte_message(val)) {
-						// message (2 bytes)
-						getd();
-					} else if(val == ':') {
-						break;
+				uint8 val = getd();
+				if (val == '\'' || val == '"') {  // SysEng
+					for (uint8_t c = getd(); c != val; c = getd()) {
+						if (c == '\\')
+							getd();
+					}
+				} else {
+					while (val != ':') {
+						if(is_2byte_message(val))
+							getd();
+						val = getd();
 					}
 				}
 			} else if(cmd == 'N') {
@@ -262,6 +264,11 @@ void NACT_Sys2::cmd_branch()
 			} else if(is_2byte_message(cmd)) {
 				// message (2 bytes)
 				getd();
+			} else if (cmd == '\'' || cmd == '"') {  // SysEng
+				for (uint8_t c = getd(); c != cmd; c = getd()) {
+					if (c == '\\')
+						getd();
+				}
 			} else {
 				if(cmd >= 0x20 && cmd < 0x7f) {
 					fatal("Unknown Command: '%c' at page = %d, addr = %d", cmd, scenario_page, prev_addr);
@@ -849,14 +856,25 @@ void NACT_Sys2::cmd_l()
 void NACT_Sys2::cmd_m()
 {
 	char string[33];
-	int d, p = 0;
+	int p = 0;
 
-	while((d = getd()) != ':') {
-		if(is_2byte_message(d)) {
+	int d = getd();
+	if (d == '\'' || d == '"') {  // SysEng
+		int terminator = d;
+		while ((d = getd()) != terminator) {
+			if (d == '\\')
+				d = getd();
 			string[p++] = d;
-			string[p++] = getd();
-		} else {
-			string[p++] = d;
+		}
+	} else {
+		while(d != ':') {
+			if(is_2byte_message(d)) {
+				string[p++] = d;
+				string[p++] = getd();
+			} else {
+				string[p++] = d;
+			}
+			d = getd();
 		}
 	}
 	string[p] = '\0';

--- a/src/sys/nact_sys3.cpp
+++ b/src/sys/nact_sys3.cpp
@@ -264,7 +264,7 @@ void NACT_Sys3::cmd_open_obj(int verb)
 	// 戻るを追加
 	ags->menu_dest_x = 2;
 	ags->menu_dest_y += 2;
-	ags->draw_text(SJIS_BACK);
+	ags->draw_text(strings::back[lang]);
 	id[index++] = 0;
 	ags->menu_dest_y += ags->menu_font_size + 2;
 	ags->draw_menu = false;

--- a/src/sys/nact_sys3.cpp
+++ b/src/sys/nact_sys3.cpp
@@ -708,14 +708,25 @@ void NACT_Sys3::cmd_l()
 void NACT_Sys3::cmd_m()
 {
 	char string[22];
-	int d, p = 0;
+	int p = 0;
 
-	while((d = getd()) != ':') {
-		if(is_2byte_message(d)) {
+	int d = getd();
+	if (d == '\'' || d == '"') {  // SysEng
+		int terminator = d;
+		while ((d = getd()) != terminator) {
+			if (d == '\\')
+				d = getd();
 			string[p++] = d;
-			string[p++] = getd();
-		} else {
-			string[p++] = d;
+		}
+	} else {
+		while(d != ':') {
+			if(is_2byte_message(d)) {
+				string[p++] = d;
+				string[p++] = getd();
+			} else {
+				string[p++] = d;
+			}
+			d = getd();
 		}
 	}
 	string[p] = '\0';

--- a/src/sys/nact_sys3.cpp
+++ b/src/sys/nact_sys3.cpp
@@ -974,7 +974,8 @@ void NACT_Sys3::cmd_u()
 
 	output_console("\nU %d,%d:", page, transparent);
 
-	if(crc32_a == CRC32_RANCE41 || crc32_a == CRC32_RANCE42) {
+	if(crc32_a == CRC32_RANCE41 || crc32_a == CRC32_RANCE41_ENG ||
+	   crc32_a == CRC32_RANCE42 || crc32_a == CRC32_RANCE42_ENG) {
 		transparent = (transparent == 28) ? 12 : transparent;
 	}
 	ags->load_cg(page, transparent);

--- a/src/win/mako.cpp
+++ b/src/win/mako.cpp
@@ -378,9 +378,17 @@ void MAKO::select_sound(BGMDevice dev)
 		const int8* tracks;
 
 		switch (nact->crc32_a) {
-		case CRC32_RANCE41: tracks = RANCE41_tracks; break;
-		case CRC32_RANCE42: tracks = RANCE42_tracks; break;
-		case CRC32_DPSALL:  tracks = DPSALL_tracks;  break;
+		case CRC32_RANCE41:
+		case CRC32_RANCE41_ENG:
+			tracks = RANCE41_tracks;
+			break;
+		case CRC32_RANCE42:
+		case CRC32_RANCE42_ENG:
+			tracks = RANCE42_tracks;
+			break;
+		case CRC32_DPSALL:
+			tracks = DPSALL_tracks;
+			break;
 
 		// For the following games, the default mapping (cd_track[i] = i) works.
 		case CRC32_AYUMI_CD:


### PR DESCRIPTION
@RottenBlock Do you mind if I merge this?

This adds support for the SysEng's command extensions, except for the multiple fonts support.

The implementation approach is a bit different from SysEng's (sorry!). Localized games have separate CRC32 entries, and language setting is done based on CRC32 rather than a command line flag.
