### PR TITLE
Install font to resource directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,7 @@ else()  # NOT (ANDROID OR EMSCRIPTEN)
     install(TARGETS system3 RUNTIME DESTINATION bin)
     install(DIRECTORY ../resources/
       DESTINATION share/system3
-      FILES_MATCHING PATTERN *.MDA)
+      FILES_MATCHING PATTERN *.MDA PATTERN *.ttf)
   endif()
 endif()
 


### PR DESCRIPTION
Fixes "Cannot open default font" error on startup.