### PR TITLE
Implement GameController through SDL2

### DIFF
--- a/src/sys/nact.cpp
+++ b/src/sys/nact.cpp
@@ -104,6 +104,20 @@ NACT::NACT(int sys_ver, uint32 crc32_a, uint32 crc32_b, const Config& config)
 	}
 #endif
 
+#ifdef USE_JOY_SDL
+	SDL_Init(SDL_INIT_GAMECONTROLLER);
+	for (int i = 0; i < SDL_NumJoysticks(); ++i) {
+		if (SDL_IsGameController(i)) {
+			sdl_gamecontroller = SDL_GameControllerOpen(i);
+			if (sdl_gamecontroller) {
+				break;
+			} else {
+				WARNING("Could not open gamecontroller %i: %s\n", i, SDL_GetError());
+			}
+		}
+	}
+#endif
+
 	terminate = false;
 	restart_after_terminate = false;
 }

--- a/src/sys/nact.h
+++ b/src/sys/nact.h
@@ -235,6 +235,10 @@ protected:
 	int joy_num;
 	JOYCAPS joycaps;
 #endif
+
+#ifdef USE_JOY_SDL
+	SDL_GameController *sdl_gamecontroller = NULL;
+#endif
 	int mouse_x = 0, mouse_y = 0;
 
 	static uint32 calc_crc32(const char* file_name, const std::string& game_id);

--- a/src/sys/nact_input.cpp
+++ b/src/sys/nact_input.cpp
@@ -102,6 +102,19 @@ uint8 NACT::get_key()
 	}
 #endif
 
+#ifdef USE_JOY_SDL
+	if(sdl_gamecontroller) {
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_DPAD_UP) || SDL_GameControllerGetAxis(sdl_gamecontroller, SDL_CONTROLLER_AXIS_LEFTY) <= -8000) val |= 0x01;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_DPAD_DOWN) || SDL_GameControllerGetAxis(sdl_gamecontroller, SDL_CONTROLLER_AXIS_LEFTY) >= 8000) val |= 0x02;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_DPAD_LEFT) || SDL_GameControllerGetAxis(sdl_gamecontroller, SDL_CONTROLLER_AXIS_LEFTX) <= -8000) val |= 0x04;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_DPAD_RIGHT) || SDL_GameControllerGetAxis(sdl_gamecontroller, SDL_CONTROLLER_AXIS_LEFTX) >= 8000) val |= 0x08;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_A)) val |= 0x10;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_B)) val |= 0x20;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_X)) val |= 0x40;
+		if(SDL_GameControllerGetButton(sdl_gamecontroller, SDL_CONTROLLER_BUTTON_Y)) val |= 0x80;
+	}
+#endif
+
 	return val;
 }
 


### PR DESCRIPTION
This adds game controller support through SDL2. Button mappings are loosely based on the existing Windows joypad support.

It's not active yet (`#ifdef`'d through `USE_JOY_SDL`) on CMake since I saw `USE_JOY` was disabled at all times, not even enabled in Windows builds. Would it be reasonable to enable it always through the CMake file considering SDL2 will always be available?