### PR TITLE
Add support for Rance 2 Hint Disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Here is a list of available game IDs and their corresponding titles:
 ----------|-------|--------
 | `bunkasai` | あぶない文化祭前夜 | |
 | `crescent` | クレセントムーンがぁる | |
+| `rance2` | Rance 2 -反逆の少女たち- | Unsupported |
+| `rance2_hint` | Rance 2 ヒントディスク | |
 | `dps` | D.P.S - Dream Program System | |
 | `dps_sg_fahren` | D.P.S SG - Fahren Fliegen | |
 | `dps_sg_katei` | D.P.S SG - 家庭教師はステキなお仕事 | |

--- a/src/sys/ags.cpp
+++ b/src/sys/ags.cpp
@@ -227,6 +227,11 @@ AGS::AGS(const Config& config, const GameId& game_id) : game_id(game_id), dirty(
 			// 本来は横メニュー
 			SET_MENU(i, 464, 50, 623, 240, true);
 			break;
+		case GameId::RANCE2:
+		case GameId::RANCE2_HINT:
+			SET_TEXT(i, 8, 285, 502, 396, false);
+			SET_MENU(i, 431, 19, 624, 181, false);
+			break;
 		case GameId::DPS:
 		case GameId::DPS_SG_FAHREN:
 		case GameId::DPS_SG_KATEI:

--- a/src/sys/ags_draw.cpp
+++ b/src/sys/ags_draw.cpp
@@ -142,8 +142,6 @@ void AGS::gcopy(int gsc, int gde, int glx, int gly, int gsw)
 
 void AGS::paint(int x, int y, uint8 color)
 {
-	if (x < 0 || y < 0) return;
-
 	int old_color = vram[0][y][x];
 	if (old_color == color)
 		return;

--- a/src/sys/ags_draw.cpp
+++ b/src/sys/ags_draw.cpp
@@ -142,6 +142,8 @@ void AGS::gcopy(int gsc, int gde, int glx, int gly, int gsw)
 
 void AGS::paint(int x, int y, uint8 color)
 {
+	if (x < 0 || y < 0) return;
+
 	int old_color = vram[0][y][x];
 	if (old_color == color)
 		return;

--- a/src/sys/dri.cpp
+++ b/src/sys/dri.cpp
@@ -14,9 +14,8 @@ void Dri::open(const char* file_name)
 {
 	link_table.clear();
 	fname = file_name;
-	fname[0] = 'A';
 
-	auto fio = FILEIO::open(fname.c_str(), FILEIO_READ_BINARY);
+	auto fio = FILEIO::open(file_name, FILEIO_READ_BINARY);
 	if (!fio)
 		return;
 

--- a/src/sys/game_id.cpp
+++ b/src/sys/game_id.cpp
@@ -73,6 +73,9 @@
 #define CRC32_NINGYO		0xd491e7ab	// 人魚 -蘿子-
 #define CRC32_MUGENHOUYOU	0xbb27d1ba	// 夢幻泡影
 
+#define CRC32_RANCE2      0x12345678
+#define CRC32_RANCE2_HINT 0x34567890
+
 namespace {
 
 const struct CRCTable {
@@ -142,6 +145,9 @@ const struct CRCTable {
 	{GameId::OTOME, "otome", 3, "乙女戦記", JAPANESE, CRC32_OTOMESENKI},
 	{GameId::NINGYO, "ningyo", 3, "人魚 -蘿子-", JAPANESE, CRC32_NINGYO},
 	{GameId::MUGEN, "mugen", 3, "夢幻泡影", JAPANESE, CRC32_MUGENHOUYOU},
+
+	{GameId::RANCE2, "rance2", 1, "Rance 2", ENGLISH, CRC32_RANCE2},
+	{GameId::RANCE2_HINT, "rance2_hint", 1, "Rance 2 Hint Disk", ENGLISH, CRC32_RANCE2_HINT},
 
 	{GameId::UNKNOWN, NULL, 0, NULL, JAPANESE, 0},
 };

--- a/src/sys/game_id.cpp
+++ b/src/sys/game_id.cpp
@@ -8,6 +8,8 @@
 
 #define CRC32_BUNKASAI		0xc80f99b8	// あぶない文化祭前夜
 #define CRC32_CRESCENT		0x42351f2c	// クレセントムーンがぁる
+#define CRC32_RANCE2		0x28f8298f	// Rance 2
+#define CRC32_RANCE2_HINT	0x2a85e5fa	// Rance 2 ヒントディスク (CRC32 of GDISK.DAT)
 #define CRC32_DPS		0x69ea4865	// D.P.S. - Dream Program System
 #define CRC32_DPS_SG		0xab4cda48	// D.P.S. SG
 #define CRC32_DPS_SG_FAHREN	0xe405d57c	//	D.P.S. SG - Fahren Fliegen
@@ -73,9 +75,6 @@
 #define CRC32_NINGYO		0xd491e7ab	// 人魚 -蘿子-
 #define CRC32_MUGENHOUYOU	0xbb27d1ba	// 夢幻泡影
 
-#define CRC32_RANCE2      0x12345678
-#define CRC32_RANCE2_HINT 0x34567890
-
 namespace {
 
 const struct CRCTable {
@@ -89,6 +88,8 @@ const struct CRCTable {
 } crc_table[] = {
 	{GameId::BUNKASAI, "bunkasai", 1, "あぶない文化祭前夜", JAPANESE, CRC32_BUNKASAI},
 	{GameId::CRESCENT, "crescent", 1, "クレセントムーンがぁる", JAPANESE, CRC32_CRESCENT},
+	{GameId::RANCE2, "rance2", 1, "Rance 2 -反逆の少女たち-", JAPANESE, CRC32_RANCE2},
+	{GameId::RANCE2_HINT, "rance2_hint", 1, "Rance 2 ヒントディスク", JAPANESE, CRC32_RANCE2_HINT},
 	{GameId::DPS, "dps", 1, "D.P.S - Dream Program System", JAPANESE, CRC32_DPS},
 	{GameId::DPS_SG_FAHREN, "dps_sg_fahren", 1, "D.P.S SG - Fahren Fliegen", JAPANESE, CRC32_DPS_SG, CRC32_DPS_SG_FAHREN},
 	{GameId::DPS_SG_KATEI, "dps_sg_katei", 1, "D.P.S SG - 家庭教師はステキなお仕事", JAPANESE, CRC32_DPS_SG, CRC32_DPS_SG_KATEI},
@@ -145,9 +146,6 @@ const struct CRCTable {
 	{GameId::OTOME, "otome", 3, "乙女戦記", JAPANESE, CRC32_OTOMESENKI},
 	{GameId::NINGYO, "ningyo", 3, "人魚 -蘿子-", JAPANESE, CRC32_NINGYO},
 	{GameId::MUGEN, "mugen", 3, "夢幻泡影", JAPANESE, CRC32_MUGENHOUYOU},
-
-	{GameId::RANCE2, "rance2", 1, "Rance 2", ENGLISH, CRC32_RANCE2},
-	{GameId::RANCE2_HINT, "rance2_hint", 1, "Rance 2 Hint Disk", ENGLISH, CRC32_RANCE2_HINT},
 
 	{GameId::UNKNOWN, NULL, 0, NULL, JAPANESE, 0},
 };

--- a/src/sys/game_id.h
+++ b/src/sys/game_id.h
@@ -17,6 +17,8 @@ struct GameId {
 		// System 1
 		BUNKASAI,
 		CRESCENT,
+		RANCE2,
+		RANCE2_HINT,
 		DPS,
 		DPS_SG_FAHREN,
 		DPS_SG_KATEI,
@@ -87,6 +89,9 @@ struct GameId {
 	}
 	bool is_sdps() const {
 		return game == SDPS_MARIA || game == SDPS_TONO || game == SDPS_KAIZOKU;
+	}
+	bool is_rance2() const {
+		return game == RANCE2 || game == RANCE2_HINT;
 	}
 	bool is_rance4x() const {
 		return game == RANCE41 || game == RANCE42;

--- a/src/sys/nact.cpp
+++ b/src/sys/nact.cpp
@@ -33,7 +33,8 @@ NACT::NACT(const Config& config, const GameId& game_id)
 	platform_initialize();
 
 	// AG00.DAT読み込み
-	auto fio = FILEIO::open("AG00.DAT", FILEIO_READ_BINARY);
+	const char* ag00_name = game_id.is(GameId::RANCE2_HINT) ? "GG00.DAT" : "AG00.DAT";
+	auto fio = FILEIO::open(ag00_name, FILEIO_READ_BINARY);
 	if (fio) {
 		int d0, d1, d2, d3;
 		std::string line = fio->gets();
@@ -49,12 +50,13 @@ NACT::NACT(const Config& config, const GameId& game_id)
 	}
 
 	// ADISK.DAT
-	if (game_id.is(GameId::PROG_OMAKE))
-		sco.open("AGAME.DAT");
-	else
-		sco.open("ADISK.DAT");
+	const char* adisk_name =
+		game_id.is(GameId::RANCE2_HINT) ? "GDISK.DAT" :
+		game_id.is(GameId::PROG_OMAKE) ? "AGAME.DAT" :
+		"ADISK.DAT";
+	sco.open(adisk_name);
 	if (!sco.loaded())
-		sys_error("Cannot open scenario file");
+		sys_error("Cannot open %s", adisk_name);
 	sco.page_jump(0, 2);
 
 	// 各種クラス生成

--- a/src/sys/nact.h
+++ b/src/sys/nact.h
@@ -228,6 +228,8 @@ protected:
 	void platform_initialize();
 	void platform_finalize();
 
+	int last_paint_x = -1, last_paint_y = -1;
+
 public:
 	int mainloop();
 	void sys_sleep(int ms);

--- a/src/sys/nact.h
+++ b/src/sys/nact.h
@@ -228,8 +228,6 @@ protected:
 	void platform_initialize();
 	void platform_finalize();
 
-	int last_paint_x = -1, last_paint_y = -1;
-
 public:
 	int mainloop();
 	void sys_sleep(int ms);
@@ -305,6 +303,8 @@ private:
 
 	// GAKUEN
 	bool enable_graphics = true;
+	// Rance 2
+	int last_paint_x = -1, last_paint_y = -1;
 };
 
 class NACT_Sys2 final : public NACT {

--- a/src/sys/nact_sys1.cpp
+++ b/src/sys/nact_sys1.cpp
@@ -431,6 +431,9 @@ void NACT_Sys1::cmd_g()
 			map_page = page;
 		}
 	}
+
+	last_paint_x = -1;
+	last_paint_y = -1;
 }
 
 void NACT_Sys1::cmd_h()
@@ -540,6 +543,9 @@ void NACT_Sys1::cmd_u()
 	} else {
 		ags->load_cg(page, transparent);
 	}
+
+	last_paint_x = -1;
+	last_paint_y = -1;
 }
 
 void NACT_Sys1::cmd_v()
@@ -701,6 +707,31 @@ void NACT_Sys1::cmd_y()
 						ags->box_fill(0, 40, 8, 598, 270, 0);
 					}
 				}
+				else if (game_id.is_rance2()) {
+					if (param == 0) {
+						// Unknown
+					}
+					else if (param == 6) {
+						ags->box_fill(0, 0, 0, 424, 276, 0);
+					}
+					else if (param == 7) {
+						ags->box_fill(0, 0, 0, 640, 276, 0);
+					}
+				}
+				break;
+			case 12:  // Rance 2 / Rance 2 hint disk
+				// Y 12, 0: is supposed to activate an automatic text
+				// progression feature, but it doesn't seem to work on the
+				// PC-98?
+			case 13: // Rance 2
+				// Sets the speed of the auto text progression feature (Y 12).
+				// The options in Rance 2 are 1 (the fastest), 5, and 10 (the 
+				// slowest). Not available in the Hint Disk.
+			case 20:  // Rance 2 / Rance 2 hint disk
+				ags->load_cg(param, -1);
+
+				last_paint_x = -1;
+				last_paint_y = -1;
 				break;
 			case 130:
 				if (game_id.is(GameId::TENGU)) {
@@ -889,6 +920,14 @@ void NACT_Sys1::cmd_z()
 			ags->copy(x + 2, 182, x + 38, 224, x, 210);
 			ags->src_screen = 0;
 		}
+		break;
+	case GameId::RANCE2:
+	case GameId::RANCE2_HINT:
+		ags->paint(last_paint_x, last_paint_y, 0);
+		ags->paint(cmd, param, 3);
+		last_paint_x = cmd;
+		last_paint_y = param;
+		break;
 	}
 }
 

--- a/src/sys/nact_sys1.cpp
+++ b/src/sys/nact_sys1.cpp
@@ -432,8 +432,10 @@ void NACT_Sys1::cmd_g()
 		}
 	}
 
-	last_paint_x = -1;
-	last_paint_y = -1;
+	if (game_id.is_rance2()) {
+		last_paint_x = -1;
+		last_paint_y = -1;
+	}
 }
 
 void NACT_Sys1::cmd_h()
@@ -543,9 +545,6 @@ void NACT_Sys1::cmd_u()
 	} else {
 		ags->load_cg(page, transparent);
 	}
-
-	last_paint_x = -1;
-	last_paint_y = -1;
 }
 
 void NACT_Sys1::cmd_v()
@@ -706,8 +705,7 @@ void NACT_Sys1::cmd_y()
 					if(param == 1) {
 						ags->box_fill(0, 40, 8, 598, 270, 0);
 					}
-				}
-				else if (game_id.is_rance2()) {
+				} else if (game_id.is_rance2()) {
 					if (param == 0) {
 						// Unknown
 					}
@@ -719,19 +717,24 @@ void NACT_Sys1::cmd_y()
 					}
 				}
 				break;
-			case 12:  // Rance 2 / Rance 2 hint disk
-				// Y 12, 0: is supposed to activate an automatic text
-				// progression feature, but it doesn't seem to work on the
-				// PC-98?
-			case 13: // Rance 2
-				// Sets the speed of the auto text progression feature (Y 12).
-				// The options in Rance 2 are 1 (the fastest), 5, and 10 (the 
-				// slowest). Not available in the Hint Disk.
-			case 20:  // Rance 2 / Rance 2 hint disk
-				ags->load_cg(param, -1);
-
-				last_paint_x = -1;
-				last_paint_y = -1;
+			case 12:
+				if (game_id.is_rance2()) {
+					// Y 12, 0: is supposed to activate an automatic text
+					// progression feature, but it doesn't seem to work on the
+					// PC-98?
+				}
+				break;
+			case 13:
+				if (game_id.is_rance2()) {
+					// Sets the speed of the auto text progression feature (Y 12).
+					// The options in Rance 2 are 1 (the fastest), 5, and 10 (the
+					// slowest). Not available in the Hint Disk.
+				}
+				break;
+			case 20:
+				if (game_id.is_rance2()) {
+					ags->load_cg(param, -1);
+				}
 				break;
 			case 130:
 				if (game_id.is(GameId::TENGU)) {
@@ -923,7 +926,8 @@ void NACT_Sys1::cmd_z()
 		break;
 	case GameId::RANCE2:
 	case GameId::RANCE2_HINT:
-		ags->paint(last_paint_x, last_paint_y, 0);
+		if (last_paint_x != -1)
+			ags->paint(last_paint_x, last_paint_y, 0);
 		ags->paint(cmd, param, 3);
 		last_paint_x = cmd;
 		last_paint_y = param;


### PR DESCRIPTION
The `NACT_Sys1` changes were contributed by @RottenBlock.

To get this to work, you need to put the followings in the current directory:

- all the `.DAT` files for Rance 2,
- `GDISK.DAT`/`GCG.DAT` from the hint disk, and
- `AG00.DAT` from the hint disk renamed to `GG00.DAT`

And run system3 with the game id `rance2_hint`.

Remaining issue:
- The positions of message box and menu must be adjusted.
